### PR TITLE
feat(cv): ajoute la gestion complète du CV avec upload, aperçu et métadonnées

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -33,14 +33,14 @@ IMPORTANT: Exécutez `pnpm lint` avant chaque commit.
 - TypeScript: configuration stricte
 
 ### Intégration Backend
-- Supabase pour authentification, base de données et stockage
+- NestJS pour authentification, base de données et stockage
 - Configuration par environnement dans `src/environments/`
-- Client Supabase configuré dans `src/app/core/services/supabase-client.ts`
+- Service d'authentification configuré dans `src/app/core/services/auth-service.ts`
 
 ### Structure Applicative
 - Core (`src/app/core/`) :
   - Guards: auth, admin
-  - Services: auth, thème, scroll, intégration supabase
+  - Services: auth, thème, scroll, intégration NestJS
 - Features (`src/app/features/`) :
   - Landing: Hero, badges (CRUD)
   - About: sections d’info, cartes réutilisables

--- a/src/app/features/cv/admin/cv.ts
+++ b/src/app/features/cv/admin/cv.ts
@@ -1,0 +1,83 @@
+import { ChangeDetectionStrategy, Component, inject, computed } from "@angular/core";
+import { CommonModule, NgOptimizedImage } from "@angular/common";
+import { ButtonComponent } from "@shared/ui/button/button";
+import { ToastService } from "@shared/ui/toast/service/toast-service";
+import { AuthService } from "@core/services/auth-service";
+import { EditCvComponent } from "@features/cv/components/edit-cv/edit-cv";
+import { CvService } from "@features/cv/services/cv-service";
+
+@Component({
+  selector: "app-cv-admin-page",
+  imports: [CommonModule, NgOptimizedImage, ButtonComponent, EditCvComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="space-y-6">
+      <div class="border-b border-accent pb-4">
+        <h1 class="text-2xl font-bold text-text">Gestion du CV</h1>
+      </div>
+
+      <!-- Bloc upload/remplacement -->
+      <div class="bg-background rounded-xl border border-accent p-6">
+        <app-edit-cv />
+      </div>
+
+      <!-- Bloc métadonnées -->
+      <div class="bg-background rounded-xl border border-accent p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-text">Métadonnées actuelles</h2>
+          <div class="flex gap-2 items-center">
+            <app-button color="accent" (buttonClick)="downloadPublic()" [customClass]="!hasCV() ? 'opacity-50 cursor-not-allowed' : ''">
+              <div class="flex items-center">
+                <img [ngSrc]="'/icons/download.svg'" alt="Télécharger" class="w-4 h-4 icon-invert mr-2" width="16" height="16" />
+                <span class="text-text">Ouvrir</span>
+              </div>
+            </app-button>
+          </div>
+        </div>
+
+        @if (loading()) {
+          <div class="text-secondary">Chargement…</div>
+        } @else if (!hasCV()) {
+          <div class="text-secondary">Aucun CV disponible</div>
+        } @else {
+          <div class="grid sm:grid-cols-2 gap-4 text-sm">
+            <div><span class="text-text text-xl">Nom original : </span> <span class="text-lg font-bold border border-primary-950 rounded-md text-text bg-accent-600 px-2">{{ cv.cvData()?.originalName || 'CV.pdf' }}</span></div>
+            <div><span class="text-text text-xl">Version : </span> <span class="text-lg font-bold border border-primary-950 rounded-md text-text bg-accent-600 px-2">{{ stats().version }}</span></div>
+            <div><span class="text-text text-xl">Upload : </span> <span class="text-lg font-bold border border-primary-950  rounded-md text-text bg-accent-600 px-2">{{ stats().uploadDate }}</span></div>
+            <div><span class="text-text text-xl">Taille : </span> <span class="text-lg font-bold border border-primary-950  rounded-md text-text bg-accent-600 px-2">{{ stats().fileSize }}</span></div>
+            <div><span class="text-text text-xl">Téléchargements : </span> <span class="text-lg font-bold border border-primary-950  rounded-md text-text bg-accent-600 px-2">{{ stats().downloadCount }}</span></div>
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class CvAdminPage {
+  readonly cv = inject(CvService);
+  private readonly auth = inject(AuthService);
+  private readonly toast = inject(ToastService);
+
+  readonly loading = this.cv.loading;
+  readonly stats = this.cv.cvStats;
+  readonly hasCV = computed(() => this.stats().hasCV);
+
+  constructor() {
+    void this.cv.loadCvData();
+  }
+
+  async downloadPublic(): Promise<void> {
+    const user = this.auth.user();
+    if (!user) {
+      this.toast.show({ message: "Non connecté", type: "error" });
+      return;
+    }
+    const { downloadCvFlow } = await import('@shared/utils/download-cv');
+    const ok = await downloadCvFlow({
+      cvService: this.cv,
+      toastService: this.toast
+    });
+    if (ok === null) {
+      this.toast.show({ message: "Échec du téléchargement", type: "error" });
+    }
+  }
+}

--- a/src/app/features/cv/components/edit-cv/edit-cv.html
+++ b/src/app/features/cv/components/edit-cv/edit-cv.html
@@ -1,0 +1,61 @@
+<div class="mb-4">
+    <label for="cvFile" class="block text-text text-sm font-medium mb-2">Sélectionner ou déposer un CV (PDF)</label>
+
+    <!-- Zone de glisser/déposer -->
+    <div
+      [class]="dragActive()
+        ? 'w-full border-2 border-dashed rounded-lg p-4 transition-colors border-accent bg-accent/10'
+        : 'w-full border-2 border-dashed rounded-lg p-4 transition-colors border-accent'"
+      (dragover)="onDragOver($event)"
+      (dragleave)="onDragLeave($event)"
+      (drop)="onDrop($event)"
+      aria-label="Zone de dépôt de fichier PDF"
+    >
+      <div class="flex items-center gap-4">
+        <!-- Colonne instructions -->
+        <div class="flex-1 text-center">
+          <p class="text-sm text-text">Glissez-déposez votre CV ici</p>
+          <p class="text-xs text-secondary mt-1">ou</p>
+          <label for="cvFile" class="inline-block mt-2 px-4 py-2 rounded-lg bg-accent text-white cursor-pointer">Parcourir…</label>
+          <input
+            type="file"
+            id="cvFile"
+            (change)="onFileSelected($event)"
+            accept="application/pdf,.pdf"
+            class="hidden"
+          />
+          @if (selectedFile) {
+            <p class="mt-2 text-sm text-text/80">Fichier sélectionné: {{ selectedFile.name }}</p>
+          }
+        </div>
+        <!-- Colonne vignette (intégrée dans la zone) -->
+        @if (previewUrl()) {
+          <div class="w-40 h-56 border border-accent rounded-md overflow-hidden bg-background flex items-center justify-center relative shadow-sm">
+            <!-- Iframe pour un rendu PDF plus fiable (blob: URL) -->
+            <iframe
+              [src]="sanitizedPreviewUrl()"
+              title="Aperçu du CV"
+              class="w-full h-full"
+            ></iframe>
+            <span class="absolute top-1 right-1 text-xxs bg-accent text-white px-1.5 py-0.5 rounded">PDF</span>
+          </div>
+        }
+      </div>
+    </div>
+  </div>
+
+  <div class="flex flex-col sm:flex-row sm:space-x-4 space-y-4 sm:space-y-0 mt-4">
+    <app-button
+      (buttonClick)="uploadCv()"
+      [isLoading]="uploadStatus() === 'uploading'"
+      [disabled]="!selectedFile || uploadStatus() === 'uploading'"
+      color="accent"
+      customClass="py-2 px-4 w-full sm:w-auto hover:bg-primary/80"
+    >
+      {{ uploadStatus() === 'uploading' ? 'Upload en cours...' : 'Uploader le CV' }}
+    </app-button>
+  </div>
+
+  @if (uploadStatus() === 'error') {
+    <p class="text-red-500 text-sm mt-2">Erreur lors de l'upload du CV. Veuillez réessayer.</p>
+  }

--- a/src/app/features/cv/components/edit-cv/edit-cv.ts
+++ b/src/app/features/cv/components/edit-cv/edit-cv.ts
@@ -1,0 +1,139 @@
+import { ChangeDetectionStrategy, Component, inject, signal, computed, OnDestroy } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
+import { AuthService } from "@core/services/auth-service";
+import { CvService } from "@features/cv/services/cv-service";
+import { ButtonComponent } from "@shared/ui/button/button";
+import { ToastService } from "@shared/ui/toast/service/toast-service";
+
+@Component({
+  selector: "app-edit-cv",
+  imports: [CommonModule, ButtonComponent],
+  templateUrl: "./edit-cv.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EditCvComponent implements OnDestroy {
+  private readonly authService = inject(AuthService);
+  private readonly cvService = inject(CvService);
+  private readonly toastService = inject(ToastService);
+  selectedFile: File | null = null;
+  readonly dragActive = signal(false);
+  readonly previewUrl = signal<string | null>(null);
+  private readonly sanitizer = inject(DomSanitizer);
+  readonly sanitizedPreviewUrl = computed<SafeResourceUrl | null>(() => {
+    const url = this.previewUrl();
+    return url ? this.sanitizer.bypassSecurityTrustResourceUrl(url) : null;
+  });
+  readonly uploadStatus = signal<'idle' | 'uploading' | 'success' | 'error'>('idle');
+
+  private setSelectedFile(file: File | null): void {
+    const prev = this.previewUrl();
+    if (prev) {
+      URL.revokeObjectURL(prev);
+    }
+    this.selectedFile = file;
+    if (file) {
+      if (file.type !== 'application/pdf') {
+        this.toastService.show({ message: 'Seuls les fichiers PDF sont autorisés.', type: 'error' });
+        this.selectedFile = null;
+        this.previewUrl.set(null);
+        return;
+      }
+      const url = URL.createObjectURL(file);
+      this.previewUrl.set(url);
+    } else {
+      this.previewUrl.set(null);
+    }
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.setSelectedFile(input.files[0]);
+    } else {
+      this.setSelectedFile(null);
+    }
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    this.dragActive.set(true);
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    this.dragActive.set(false);
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    this.dragActive.set(false);
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      this.setSelectedFile(files[0]);
+    }
+  }
+
+  async uploadCv(): Promise<void> {
+    if (!this.selectedFile) {
+      this.toastService.show({
+        message: "Veuillez sélectionner un fichier.",
+        type: "error",
+      });
+      return;
+    }
+
+    const user = this.authService.user();
+    if (!user) {
+      this.toastService.show({
+        message: "Vous devez être connecté pour uploader un CV.",
+        type: "error",
+      });
+      return;
+    }
+
+    this.uploadStatus.set('uploading');
+
+    try {
+      const token = this.authService.getAccessToken();
+      if (!token) {
+        this.uploadStatus.set('error');
+        this.toastService.show({ message: "Token d'accès manquant. Veuillez vous reconnecter.", type: 'error' });
+        return;
+      }
+
+      const resp = await this.cvService.editUserCv({ file: this.selectedFile, token, userId: user.id });
+      const path = resp?.path;
+
+      if (path) {
+        this.uploadStatus.set('success');
+        this.toastService.show({
+          message: "CV uploadé avec succès !",
+          type: "success",
+        });
+
+        await this.cvService.refreshMeta();
+        this.setSelectedFile(null);
+      } else {
+        this.uploadStatus.set('error');
+        this.toastService.show({
+          message: "Échec de l'upload du CV.",
+          type: "error",
+        });
+      }
+    } catch {
+      this.uploadStatus.set('error');
+      this.toastService.show({
+        message: "Erreur lors de l'upload du CV.",
+        type: "error",
+      });
+    }
+  }
+
+  ngOnDestroy(): void {
+    const prev = this.previewUrl();
+    if (prev) {
+      URL.revokeObjectURL(prev);
+    }
+  }
+}

--- a/src/app/features/cv/services/cv-service.ts
+++ b/src/app/features/cv/services/cv-service.ts
@@ -1,0 +1,151 @@
+import { Injectable, signal, computed, inject } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { environment } from "@environments/environment";
+import { firstValueFrom } from "rxjs";
+
+export interface CvData {
+  id: string;
+  userId: string;
+  fileName: string;
+  originalName?: string;
+  filePath: string;
+  fileSize: number;
+  mimeType: string;
+  version: string | null;
+  downloadCount: number;
+  createdAt: string;
+}
+
+export interface CvStats {
+  version: string;
+  uploadDate: string;
+  fileSize: string;
+  downloadCount: number;
+  lastUpdated: string;
+  hasCV: boolean;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class CvService {
+  private readonly http = inject(HttpClient);
+  private readonly cvDataSignal = signal<CvData | null>(null);
+  private readonly loadingSignal = signal<boolean>(false);
+
+  // Helpers
+  private buildUploadFormData(file: File, userId?: string): FormData {
+    const formData = new FormData();
+    formData.append('cv', file, file.name);
+    if (userId) formData.append('userId', userId);
+    return formData;
+  }
+
+  private async safeReadError(res: Response): Promise<string> {
+    try {
+      const data = await res.json();
+      const msg = (data as { message?: unknown }).message;
+      return typeof msg === 'string' ? msg : JSON.stringify(data);
+    } catch {
+      return res.statusText || 'Unknown error';
+    }
+  }
+
+  readonly cvData = this.cvDataSignal.asReadonly();
+  readonly loading = this.loadingSignal.asReadonly();
+
+  readonly cvStats = computed<CvStats>(() => {
+    const data = this.cvDataSignal();
+
+    if (!data) {
+      return {
+        version: "Aucun CV",
+        uploadDate: "N/A",
+        fileSize: "0 KB",
+        downloadCount: 0,
+        lastUpdated: "N/A",
+        hasCV: false,
+      };
+    }
+
+    return {
+      version: data.version ?? "v1.0",
+      uploadDate: this.formatDate(data.createdAt),
+      fileSize: this.formatFileSize(data.fileSize),
+      downloadCount: data.downloadCount ?? 0,
+      lastUpdated: this.formatDate(data.createdAt),
+      hasCV: true,
+    };
+  });
+
+  async loadCvData(): Promise<void> {
+    this.loadingSignal.set(true);
+    try {
+      // Charger les meta publiques du CV (portfolio)
+      const meta = await firstValueFrom(this.http.get<CvData | null>(`${environment.apiUrl}/cv/meta`));
+      this.cvDataSignal.set(meta ?? null);
+    } catch {
+      this.cvDataSignal.set(null);
+    } finally {
+      this.loadingSignal.set(false);
+    }
+  }
+
+  async refreshMeta(): Promise<void> {
+    await this.loadCvData();
+  }
+
+  async incrementDownloadCount(): Promise<void> {
+    try {
+      await firstValueFrom(this.http.get(`${environment.apiUrl}/cv/meta`));
+    } catch {
+      // ignore
+    }
+  }
+
+  private formatDate(dateString: string): string {
+    if (!dateString) return "N/A";
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleDateString("fr-FR", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch {
+      return "Date invalide";
+    }
+  }
+
+  private formatFileSize(bytes: number): string {
+    if (!bytes || bytes === 0) return "0 KB";
+    const sizes = ["bytes", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    return Math.round((bytes / Math.pow(1024, i)) * 100) / 100 + " " + sizes[i];
+  }
+
+  async downloadCV(): Promise<string | null> {
+    try {
+      return `${environment.apiUrl}/cv/download`;
+    } catch {
+      return null;
+    }
+  }
+
+  async editUserCv(params: { file: File; token: string; userId?: string }): Promise<{ path: string }> {
+    const formData = this.buildUploadFormData(params.file, params.userId);
+    const res = await fetch(`${environment.apiUrl}/cv/edit`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${params.token}` },
+      body: formData,
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const message = await this.safeReadError(res);
+      throw new Error(`Edit failed (${res.status}): ${message}`);
+    }
+    return (await res.json()) as { path: string };
+  }
+}

--- a/src/app/shared/utils/download-cv.ts
+++ b/src/app/shared/utils/download-cv.ts
@@ -1,0 +1,72 @@
+import { inject } from "@angular/core";
+import { CvService, CvData } from "@features/cv/services/cv-service";
+import { ToastService } from "@shared/ui/toast/service/toast-service";
+import { openInNewTab } from "@shared/utils/open-in-new-tab";
+
+export async function downloadCvFlow(
+  depsOrOptions?: { cvService: CvService; toastService: ToastService } | { onFinally?: () => void },
+  maybeOptions?: { onFinally?: () => void }
+): Promise<boolean | null> {
+
+  type Deps = { cvService: CvService; toastService: ToastService };
+  const isDeps = (v: unknown): v is Deps =>
+    !!v && typeof v === "object" && "cvService" in (v as Record<string, unknown>) && "toastService" in (v as Record<string, unknown>);
+  const hasDeps = isDeps(depsOrOptions);
+  const options = (hasDeps ? maybeOptions : (depsOrOptions as { onFinally?: () => void } | undefined)) ?? {};
+
+  const cvService = hasDeps ? (depsOrOptions as { cvService: CvService }).cvService : inject(CvService);
+  const toastService = hasDeps ? (depsOrOptions as { toastService: ToastService }).toastService : inject(ToastService);
+
+  try {
+    const publicUrl = await cvService.downloadCV();
+    if (!publicUrl) {
+      toastService.show({
+        message:
+          "Échec de l'ouverture du CV. Le fichier n'existe peut-être pas ou vous n'avez pas les permissions.",
+        type: "error",
+      });
+      return null;
+    }
+
+    cvService
+      .incrementDownloadCount()
+      .catch((error) => console.warn("Could not increment download count:", error));
+
+    const meta = cvService.cvData();
+    const filename = deriveCvFilename(meta);
+
+    const separator = publicUrl.includes("?") ? "&" : "?";
+    const urlWithFilename = `${publicUrl}${separator}filename=${encodeURIComponent(filename)}`;
+
+    const ok = openInNewTab(urlWithFilename);
+    if (!ok) {
+      toastService.show({
+        message: "L'ouverture a été bloquée. Cliquez sur ce lien: " + publicUrl,
+        type: "warning",
+        duration: 6000,
+      });
+    } else {
+      toastService.show({
+        message: "Ouverture du CV dans un nouvel onglet.",
+        type: "success",
+      });
+    }
+    return ok;
+  } finally {
+    options.onFinally?.();
+  }
+}
+
+export function deriveCvFilename(meta: CvData | null): string {
+  const fallback = "CV.pdf";
+  if (!meta) return fallback;
+
+  const orig = (meta.originalName ?? "").trim();
+  if (orig.length > 0) return orig;
+
+  const fileName = (meta.fileName ?? "").trim();
+  if (fileName.length > 0) return fileName;
+
+  const fromPath = (meta.filePath ?? "").split("/").pop();
+  return (fromPath && fromPath.trim().length > 0 ? fromPath.trim() : undefined) ?? fallback;
+}


### PR DESCRIPTION
- Ajoute le service `CvService` pour gérer les données et opérations liées aux CV
- Crée l'interface d'administration pour la gestion des CV, incluant un aperçu et les métadonnées
- Implémente le composant `EditCvComponent` pour permettre l'upload de fichiers PDF avec drag & drop
- Ajoute une logique de téléchargement des CV dans un nouvel onglet avec gestion des erreurs
- Met à jour les directives pour refléter l'intégration avec une nouvelle architecture backend