### PR TITLE
feat(services): implémente `CvService` pour la gestion des CV et uniformise les importations

### DIFF
--- a/src/app/features/admin/admin.ts
+++ b/src/app/features/admin/admin.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterOutlet } from '@angular/router';
-import { AuthService } from '@core/services/auth.service';
+import { AuthService } from '@core/services/auth';
 import { AdminSidebar } from './components/admin-sidebar/admin-sidebar';
 
 @Component({

--- a/src/app/features/admin/pages/cv-admin/cv-admin.ts
+++ b/src/app/features/admin/pages/cv-admin/cv-admin.ts
@@ -2,20 +2,8 @@ import { Component, ChangeDetectionStrategy, signal, computed, inject } from '@a
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { ButtonComponent } from '@shared/ui/button/button';
 import { ToastService } from '@shared/ui';
-import { CvService } from '../../../services/cv.service';
-
-export interface CvMetadata {
-  id: string;
-  userId: string;
-  fileName: string;
-  originalName?: string;
-  filePath: string;
-  fileSize: number;
-  mimeType: string;
-  version: string | null;
-  downloadCount: number;
-  createdAt: string;
-}
+import { CvService } from '../../../services/cv';
+import type { CvMetadata } from '@core/interfaces';
 
 @Component({
   selector: 'app-cv-admin',
@@ -279,9 +267,7 @@ export interface CvMetadata {
       </div>
     </div>
   `,
-  styles: `
-    @tailwind utilities;
-  `,
+  styles: ``,
 })
 export class CvAdminComponent {
   private readonly cvService = inject(CvService);

--- a/src/app/features/services/cv.ts
+++ b/src/app/features/services/cv.ts
@@ -1,0 +1,103 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import type { CvMetadata, UploadCvResponse } from '@core/interfaces';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CvService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = 'http://localhost:3000/api/cv';
+
+  async uploadCv(file: File, userId?: string): Promise<UploadCvResponse> {
+    const formData = new FormData();
+    formData.append('cv', file);
+
+    if (userId) {
+      formData.append('userId', userId);
+    }
+
+    try {
+      return await firstValueFrom(
+        this.http.put<UploadCvResponse>(`${this.baseUrl}/edit`, formData, {
+          withCredentials: true // Utilise les cookies pour l'authentification
+        })
+      );
+    } catch (error: unknown) {
+      console.error('Erreur upload CV:', error);
+      throw new Error(this.getErrorMessage(error));
+    }
+  }
+
+  async getCurrentCvMetadata(userId?: string): Promise<CvMetadata> {
+    try {
+      const url = userId ? `${this.baseUrl}/meta/${userId}` : `${this.baseUrl}/meta`;
+      return await firstValueFrom(
+        this.http.get<CvMetadata>(url, {
+          withCredentials: true
+        })
+      );
+    } catch (error: unknown) {
+      console.error('Erreur récupération métadonnées CV:', error);
+      throw new Error(this.getErrorMessage(error));
+    }
+  }
+
+  async downloadCv(userId?: string): Promise<Blob> {
+    try {
+      const url = userId ? `${this.baseUrl}/download/${userId}` : `${this.baseUrl}/download`;
+      return await firstValueFrom(
+        this.http.get(url, {
+          responseType: 'blob',
+          withCredentials: true
+        })
+      );
+    } catch (error: unknown) {
+      console.error('Erreur téléchargement CV:', error);
+      throw new Error(this.getErrorMessage(error));
+    }
+  }
+
+  getDownloadUrl(userId?: string): string {
+    return userId ? `${this.baseUrl}/download/${userId}` : `${this.baseUrl}/download`;
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error && typeof error === 'object' && 'error' in error && error.error && typeof error.error === 'object' && 'message' in error.error) {
+      return error.error.message as string;
+    }
+
+    if (error && typeof error === 'object' && 'status' in error) {
+      const httpError = error as { status: number; message?: string };
+
+      if (httpError.status === 401) {
+        return 'Non autorisé. Veuillez vous reconnecter.';
+      }
+
+      if (httpError.status === 403) {
+        return 'Accès refusé. Vous n\'avez pas les permissions nécessaires.';
+      }
+
+      if (httpError.status === 404) {
+        return 'CV non trouvé.';
+      }
+
+      if (httpError.status === 400) {
+        return 'Fichier invalide. Veuillez vérifier le format et la taille.';
+      }
+
+      if (httpError.status === 413) {
+        return 'Fichier trop volumineux. Maximum 10 MB autorisé.';
+      }
+
+      if (httpError.status === 0) {
+        return 'Impossible de contacter le serveur. Vérifiez votre connexion.';
+      }
+
+      return `Erreur ${httpError.status ?? 'inconnue'}: ${httpError.message ?? 'Une erreur s\'est produite'}`;
+    }
+
+    return 'Une erreur s\'est produite';
+  }
+}

--- a/src/app/shared/ui/navbar/navbar.ts
+++ b/src/app/shared/ui/navbar/navbar.ts
@@ -9,7 +9,7 @@ import {
 import { NgOptimizedImage } from '@angular/common';
 import { Router, RouterLink } from '@angular/router';
 import { NavLink } from './interface/nav-link';
-import { AuthService } from '@core/services/auth.service';
+import { AuthService } from '@core/services/auth';
 import { ButtonComponent } from '@shared/ui/button/button';
 
 @Component({


### PR DESCRIPTION
- Ajoute le service `CvService` avec des méthodes pour uploader, télécharger et récupérer les métadonnées des CV.
- Déplace et uniformise les chemins d'importation pour `AuthService` et `CvService` dans l'application.
- Simplifie et nettoie les définitions de styles inutilisées dans `CvAdminComponent`.