### PR TITLE
refactor(ui): remplace les boutons natifs par `ButtonComponent` dans login-form et modal

### DIFF
--- a/src/app/shared/ui/index.ts
+++ b/src/app/shared/ui/index.ts
@@ -1,4 +1,5 @@
 export { NavbarComponent } from './navbar/navbar';
+export { ButtonComponent } from './button/button';
 export { LoginForm } from '@shared/ui/login/login-form/login-form';
 export { LoginModal } from '@shared/ui/login/login-modal/login-modal';
 export { Toast } from './toast/toast';

--- a/src/app/shared/ui/login/login-form/login-form.ts
+++ b/src/app/shared/ui/login/login-form/login-form.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, signal, inject, output, effect } fr
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { AuthService, LoginRequest } from '@core/services/auth';
 import { NgOptimizedImage } from '@angular/common';
+import { ButtonComponent } from '@shared/ui/button/button';
 
 interface LoginFormControls {
   email: FormControl<string>;
@@ -10,7 +11,7 @@ interface LoginFormControls {
 
 @Component({
   selector: 'app-login-form',
-  imports: [ReactiveFormsModule, NgOptimizedImage],
+  imports: [ReactiveFormsModule, NgOptimizedImage, ButtonComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div
@@ -162,22 +163,15 @@ interface LoginFormControls {
           }
 
           <div>
-            <button
+            <app-button
               type="submit"
+              color="accent"
               [disabled]="loginForm.invalid || authService.isLoading()"
-              class="group relative w-full flex justify-center py-3 px-4 border border-transparent
-                     text-sm font-medium rounded-lg text-white bg-accent hover:bg-accent-600
-                     focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent
-                     disabled:opacity-50 disabled:cursor-not-allowed
-                     transition-all duration-200"
+              [isLoading]="authService.isLoading()"
+              (buttonClick)="onSubmit()"
             >
               @if (authService.isLoading()) {
-                <div class="flex items-center space-x-2">
-                  <div
-                    class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"
-                  ></div>
-                  <span>Connexion en cours...</span>
-                </div>
+                <span>Connexion en cours...</span>
               } @else {
                 <div class="flex items-center space-x-2">
                   <img
@@ -190,18 +184,18 @@ interface LoginFormControls {
                   <span>Se connecter</span>
                 </div>
               }
-            </button>
+            </app-button>
           </div>
         </form>
 
         <!-- Close Button -->
         <div class="text-center">
-          <button
+          <app-button
             type="button"
-            (click)="closeLogin()"
-            class="inline-flex items-center px-4 py-2 text-sm text-secondary hover:text-text
-                   transition-colors duration-200"
+            color="secondary"
             [disabled]="authService.isLoading()"
+            customClass="inline-flex items-center px-4 py-2 text-sm w-auto"
+            (buttonClick)="closeLogin()"
           >
             <img
               ngSrc="/icons/arrow-left.svg"
@@ -212,7 +206,7 @@ interface LoginFormControls {
               [class.icon-invert]="isDarkMode()"
             />
             Retour à l'accueil
-          </button>
+          </app-button>
         </div>
       </div>
     </div>
@@ -283,7 +277,6 @@ export class LoginForm {
         this.loginSuccess.emit();
       },
       error: (error) => {
-        // L'erreur est déjà gérée dans le service via tap
         console.error('Erreur de connexion:', error);
       },
     });

--- a/src/app/shared/ui/login/login-modal/login-modal.ts
+++ b/src/app/shared/ui/login/login-modal/login-modal.ts
@@ -25,20 +25,15 @@ import { NgOptimizedImage } from '@angular/common';
             aria-labelledby="modal-title"
             tabindex="-1"
           >
-            <button
-              type="button"
+            <img
+              [ngSrc]="'icons/close.svg'"
+              alt="Fermer"
+              width="16"
+              height="16"
+              class="absolute right-4 top-4 z-10 h-4 w-4 cursor-pointer hover:opacity-70 transition-opacity"
               (click)="closeModal()"
-              class="absolute right-4 top-4 z-10 rounded-full p-2 text-secondary hover:text-text hover:bg-primary-100 transition-colors"
-              aria-label="Fermer la modal"
-            >
-              <img
-                [ngSrc]="'icons/close.svg'"
-                alt="Fermer"
-                width="16"
-                height="16"
-                class="h-4 w-4"
-              />
-            </button>
+              [attr.aria-label]="'Fermer la modal'"
+            />
 
             <app-login-form (loginSuccess)="onLoginSuccess()" (loginCancel)="onLoginCancel()" />
           </div>


### PR DESCRIPTION
- Utilise le composant générique `ButtonComponent` pour uniformiser le style et le comportement des boutons.
- Simplifie la gestion des états comme `isLoading` via les propriétés du composant.
- Élimine les styles inline et classes CSS redondantes pour un code plus concis et maintenable.