### PR TITLE
build(docker): remplace npm par pnpm dans le Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Installe les dépendances
-RUN npm install
+RUN pnpm install
 
 # Copie tout le code source
 COPY . .
@@ -25,7 +25,7 @@ RUN mkdir -p src/environments && \
     echo "};" >> src/environments/environment.ts
 
 # Build l'application Angular en mode production
-RUN npm run build -- --configuration production
+RUN pnpm run build -- --configuration production
 
 # ---- Étape de production ----
 # Utilise Nginx Alpine comme image finale légère


### PR DESCRIPTION
- Modifie les commandes d'installation et de build pour utiliser `pnpm` au lieu de `npm`.
- Améliore les performances du build en tirant parti de la rapidité de `pnpm`.
- Met à jour la base du workflow de conteneurisation pour refléter ce changement.