### PR TITLE
refactor(contact): déplace le footer au niveau global et conditionne son affichage

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -9,5 +9,7 @@
   <main class="flex-1">
     <router-outlet />
   </main>
-
+  @if (showFooter()) {
+  <app-footer />
+    }
 </div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,10 +1,13 @@
-import { Component, signal, viewChild, inject } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Component, signal, viewChild, inject, computed } from '@angular/core';
+import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { LoginModal, NavbarComponent, ToastContainer, ToastService } from '@shared/ui';
+import { FooterComponent } from '@shared/ui/footer/footer.component';
+import { filter, map } from 'rxjs/operators';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, NavbarComponent, LoginModal, ToastContainer],
+  imports: [RouterOutlet, NavbarComponent, LoginModal, ToastContainer, FooterComponent],
   templateUrl: './app.html',
   styleUrl: './app.css',
   host: {
@@ -13,10 +16,23 @@ import { LoginModal, NavbarComponent, ToastContainer, ToastService } from '@shar
   },
 })
 export class App {
+  private readonly router = inject(Router);
   private readonly toastService = inject(ToastService);
 
-  protected readonly title = signal('ng-portfolio-app');
+  private readonly currentUrl = toSignal(
+    this.router.events.pipe(
+      filter((event) => event instanceof NavigationEnd),
+      map((event: NavigationEnd) => event.url),
+    ),
+    { initialValue: this.router.url },
+  );
 
+  readonly showFooter = computed(() => {
+    const url = this.currentUrl();
+    return url === '/contact';
+  });
+
+  protected readonly title = signal('ng-portfolio-app');
   readonly loginModal = viewChild<LoginModal>('loginModal');
 
   onShowLogin(): void {

--- a/src/app/features/contact/contact.html
+++ b/src/app/features/contact/contact.html
@@ -97,4 +97,3 @@
     </button>
   </div>
 </main>
-<app-footer />

--- a/src/app/features/contact/contact.ts
+++ b/src/app/features/contact/contact.ts
@@ -5,11 +5,10 @@ import { Router } from '@angular/router';
 import { ContactCardGroup } from './interface/contact.interface';
 import { CONTACT_DATA } from './data/contact-data';
 import { ContactMessageCard } from '@features/contact/components/contact-message-card/contact-message-card';
-import { FooterComponent } from '@shared/ui/footer/footer.component';
 
 @Component({
   selector: 'app-contact',
-  imports: [NgOptimizedImage, ReactiveFormsModule, ContactMessageCard, FooterComponent],
+  imports: [NgOptimizedImage, ReactiveFormsModule, ContactMessageCard],
   templateUrl: './contact.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
- Supprime l'utilisation du `FooterComponent` dans le composant `contact`.
- Ajoute l'import de `FooterComponent` et la logique pour le rendre dynamique dans `app`.
- Affiche le footer uniquement sur la page de contact via la propriété `showFooter`.