### PR TITLE
feat(services): utilise le nom de fichier original lors du téléchargement du CV

### DIFF
--- a/src/app/features/cv/services/cv.ts
+++ b/src/app/features/cv/services/cv.ts
@@ -69,12 +69,16 @@ export class CvService {
 
   async downloadCvAndNotify(userId?: string): Promise<void> {
     try {
+      // Récupérer les métadonnées pour obtenir le nom original
+      const metadata = await this.getCurrentCvMetadata(userId);
+      const fileName = (metadata.originalName ?? metadata.fileName) || 'CV.pdf';
+
       const blob = await this.downloadCv(userId);
 
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = 'CV.pdf';
+      link.download = fileName;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);


### PR DESCRIPTION
- Récupère les métadonnées pour déterminer le nom de fichier original, améliorant l'expérience utilisateur.
- Définit automatiquement `fileName` comme nom par défaut ou utilise 'CV.pdf' en fallback.