### PR TITLE
refactor(projects): centralise et optimise le tri des projets par priorité

### DIFF
--- a/src/app/features/projects/components/project-manager.ts
+++ b/src/app/features/projects/components/project-manager.ts
@@ -6,6 +6,7 @@ import { ProjectService } from '@features/projects/services/project-service';
 import { ProjectModel } from '@features/projects/models/project-model';
 import { ButtonComponent } from '@shared/ui/button/button';
 import { Router } from '@angular/router';
+import { sortProjectsByPriority } from '@features/projects/utils/project-sort';
 
 @Component({
   selector: 'app-project-manager',
@@ -421,7 +422,10 @@ export class ProjectManagerComponent {
   private readonly projectsResponse = toSignal(from(this.projectService.getAllProjects()), {
     initialValue: { projects: [], total: 0, page: 1, limit: 10, totalPages: 0 },
   });
-  readonly projects = computed(() => this.projectsResponse()?.projects || []);
+  readonly projects = computed(() => {
+    const list = this.projectsResponse()?.projects || [];
+    return sortProjectsByPriority(list);
+  });
 
   setView(view: 'list' | 'grid'): void {
     this.currentView.set(view);

--- a/src/app/features/projects/project.ts
+++ b/src/app/features/projects/project.ts
@@ -8,6 +8,7 @@ import { ProjectService } from './services/project-service';
 import { Router } from '@angular/router';
 import { ProjectCategory } from '@features/projects/enums/project-enum';
 import { TECHNOLOGIES, Technology } from '@features/projects/data/technologies';
+import { sortProjectsByPriority } from '@features/projects/utils/project-sort';
 
 @Component({
   selector: 'app-project',
@@ -57,7 +58,9 @@ export class Project implements OnInit {
 
       const response = await this.projectService.getAllProjects(filterParams);
 
-      this.allProjects.set(response.projects);
+      const sorted = sortProjectsByPriority(response.projects);
+
+      this.allProjects.set(sorted);
       this.totalPages.set(response.totalPages);
       this.totalProjects.set(response.total);
     } catch {

--- a/src/app/features/projects/utils/project-sort.ts
+++ b/src/app/features/projects/utils/project-sort.ts
@@ -1,0 +1,12 @@
+import { ProjectModel } from '@features/projects/models/project-model';
+
+export function compareProjectsByPriority(a: ProjectModel, b: ProjectModel): number {
+  const priorityA = a.priority ?? Number.POSITIVE_INFINITY;
+  const priorityB = b.priority ?? Number.POSITIVE_INFINITY;
+
+  return priorityA !== priorityB ? priorityA - priorityB : new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+}
+
+export function sortProjectsByPriority<T extends ProjectModel>(list: readonly T[]): T[] {
+  return [...list].sort(compareProjectsByPriority);
+}


### PR DESCRIPTION
- Introduit `sortProjectsByPriority` et `compareProjectsByPriority` dans un fichier utilitaire dédié.
- Applique la fonction de tri aux composants `project` et `project-manager` pour un tri cohérent.